### PR TITLE
Add Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+interface LRFUExpirerOptions {
+  lruSize?: number;
+  cleanupInterval?: number;
+}
+
+export class LRFUExpirer {
+  constructor(options?: LRFUExpirerOptions);
+}
+
+interface WeakLRUCacheOptions {
+  cacheSize?: number;
+  expirer?: LRFUExpirer | false;
+  deferRegister?: boolean;
+}
+
+export class WeakLRUCache<K, V> extends Map<K, V> {
+  constructor(options?: WeakLRUCacheOptions);
+
+  getValue(key: K, expirationPriority?: number): V | undefined;
+  setValue(key: K, value: V, expirationPriority?: number): void;
+}


### PR DESCRIPTION
There is already a "types" field in package.json, so npm lists the package as being TS-compatible when it isn't. This is a quick fix for that